### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Net
 
-Net is a PowerShell module for inspecting network configuration data from PowerShell.
-
-## Prerequisites
-
-- PowerShell with `Microsoft.PowerShell.PSResourceGet` available for `Install-PSResource`.
-- The [PSModule framework](https://github.com/PSModule) is used for building, testing, and publishing the module.
+Net is a PowerShell module for network-related functions.
 
 ## Installation
 
@@ -16,33 +11,16 @@ Install-PSResource -Name Net
 Import-Module -Name Net
 ```
 
-## Commands
-
-- `Get-NetIPConfiguration` retrieves network interface IP configuration, including addresses, prefix lengths, gateways, and DNS servers.
-
-## Usage
-
-List IP configuration for all interfaces:
-
-```powershell
-Get-NetIPConfiguration
-```
-
-List active IPv4 configuration only:
-
-```powershell
-Get-NetIPConfiguration -InterfaceStatus Up -AddressFamily IPv4
-```
-
-The command is also available through the `IPConfig` alias:
-
-```powershell
-IPConfig -AddressFamily IPv6
-```
-
 ## Documentation
 
-Command documentation is published at [psmodule.io/Net](https://psmodule.io/Net/).
+Documentation is published at [psmodule.io/Net](https://psmodule.io/Net/).
+
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module Net
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Net
-Get-Help <CommandName> -Examples
+Get-Help -Name 'CommandName' -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,69 +1,49 @@
-# {{ NAME }}
+# Net
 
-{{ DESCRIPTION }}
+Net is a PowerShell module for inspecting network configuration data from PowerShell.
 
 ## Prerequisites
 
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule/Process-PSModule) for building, testing and publishing the module.
+- PowerShell with `Microsoft.PowerShell.PSResourceGet` available for `Install-PSResource`.
+- The [PSModule framework](https://github.com/PSModule) is used for building, testing, and publishing the module.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-PSResource -Name {{ NAME }}
-Import-Module -Name {{ NAME }}
+Install-PSResource -Name Net
+Import-Module -Name Net
 ```
+
+## Commands
+
+- `Get-NetIPConfiguration` retrieves network interface IP configuration, including addresses, prefix lengths, gateways, and DNS servers.
 
 ## Usage
 
-Here is a list of example that are typical use cases for the module.
-
-### Example 1: Greet an entity
-
-Provide examples for typical commands that a user would like to do with the module.
+List IP configuration for all interfaces:
 
 ```powershell
-Greet-Entity -Name 'World'
-Hello, World!
+Get-NetIPConfiguration
 ```
 
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
+List active IPv4 configuration only:
 
 ```powershell
-Import-Module -Name PSModuleTemplate
+Get-NetIPConfiguration -InterfaceStatus Up -AddressFamily IPv4
 ```
 
-### Find more examples
+The command is also available through the `IPConfig` alias:
 
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
+```powershell
+IPConfig -AddressFamily IPv6
+```
 
 ## Documentation
 
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+Command documentation is published at [psmodule.io/Net](https://psmodule.io/Net/).
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
README pages now act as concise landing pages. Implemented modules point users to installation, psmodule.io, and PowerShell help instead of duplicating command reference content. Placeholder and in-progress modules now state their status clearly so users are not shown scaffold examples as working usage.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: README pages defer to generated documentation

Implemented module READMEs now provide a short overview, installation commands, and links to generated documentation. Command usage remains in PowerShell help and generated docs.

```powershell
Get-Command -Module <ModuleName>
Get-Help -Name 'CommandName' -Examples
```

## Changed: Placeholder modules identify their status

Repositories that still contain scaffold or stub module code now say they are placeholders or in progress instead of showing template commands as if they worked.

## Technical Details

- Updates `README.md` only.
- Aligns repository READMEs with the default introduced in `PSModule/Template-PSModule`.
- Keeps command-level details out of README pages to avoid duplicating generated module documentation.
